### PR TITLE
Make it possible to pass in arguments when starting the tcp server.

### DIFF
--- a/include/gen_tcp_server.hrl
+++ b/include/gen_tcp_server.hrl
@@ -20,6 +20,5 @@
 
 %% Default options for gen_tcp:listen/3.
 -define(GEN_TCP_SERVER_OPTS, [binary,
-                              {packet, raw},
                               {active, once},
                               {reuseaddr, true}]).

--- a/src/gen_tcp_server.erl
+++ b/src/gen_tcp_server.erl
@@ -22,13 +22,14 @@
 %% API
 -export([start_link/2,
          start_link/3,
+         start_link/4,
          stop/1]).
 
 %%------------------------------------------------------------------------------
 %% gen_tcp_server callback definitions
 %%------------------------------------------------------------------------------
 
--callback handle_accept(Socket :: term()) ->
+-callback handle_accept(Socket :: term(), Args :: term()) ->
     {ok, State :: term()} | {stop, Reason :: term()}.
 
 -callback handle_tcp(Socket :: term(), Data :: binary(), State :: term()) ->
@@ -48,13 +49,19 @@
 -spec start_link(atom(), integer()) -> {ok, Pid :: pid()} | ignore |
                                        {error, Reason :: term()}.
 start_link(HandlerModule, Port) ->
-    start_link(HandlerModule, Port, []).
+    start_link(HandlerModule, Port, [], []).
+
+%% @doc Start gen_tcp_server with default options.
+-spec start_link(atom(), integer(), term()) -> {ok, Pid :: pid()} | ignore |
+                                               {error, Reason :: term()}.
+start_link(HandlerModule, Port, Opts) ->
+    start_link(HandlerModule, Port, Opts, []).
 
 %% @doc Start gen_tcp_server with custom options.
--spec start_link(atom(), integer(), [term()]) -> {ok, Pid :: pid()} | ignore |
-                                                 {error, Reason :: term()}.
-start_link(HandlerModule, Port, Opts) ->
-    {ok, Pid} = gen_tcp_server_sup:start_link(HandlerModule, Port, Opts),
+-spec start_link(atom(), integer(), [term()], term()) -> {ok, Pid :: pid()} | ignore |
+                                                         {error, Reason :: term()}.
+start_link(HandlerModule, Port, Opts, Args) ->
+    {ok, Pid} = gen_tcp_server_sup:start_link(HandlerModule, Port, Opts, Args),
     N = case lists:keyfind(pool, 1, Opts) of
             false ->
                 1;

--- a/src/gen_tcp_server.erl
+++ b/src/gen_tcp_server.erl
@@ -45,19 +45,19 @@
 %% API functions
 %%------------------------------------------------------------------------------
 
-%% @doc Start gen_tcp_server with default options.
+%% @doc Start gen_tcp_server with default options and no arguments.
 -spec start_link(atom(), integer()) -> {ok, Pid :: pid()} | ignore |
                                        {error, Reason :: term()}.
 start_link(HandlerModule, Port) ->
     start_link(HandlerModule, Port, [], []).
 
-%% @doc Start gen_tcp_server with default options.
--spec start_link(atom(), integer(), term()) -> {ok, Pid :: pid()} | ignore |
+%% @doc Start gen_tcp_server with custom options and no arguments.
+-spec start_link(atom(), integer(), [term()]) -> {ok, Pid :: pid()} | ignore |
                                                {error, Reason :: term()}.
 start_link(HandlerModule, Port, Opts) ->
     start_link(HandlerModule, Port, Opts, []).
 
-%% @doc Start gen_tcp_server with custom options.
+%% @doc Start gen_tcp_server with custom options and arguments.
 -spec start_link(atom(), integer(), [term()], term()) -> {ok, Pid :: pid()} | ignore |
                                                          {error, Reason :: term()}.
 start_link(HandlerModule, Port, Opts, Args) ->

--- a/src/gen_tcp_server_sup.erl
+++ b/src/gen_tcp_server_sup.erl
@@ -23,7 +23,7 @@
 -behaviour(supervisor).
 
 %% Internal API
--export([start_link/3]).
+-export([start_link/4]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -35,22 +35,23 @@
 %%------------------------------------------------------------------------------
 
 %% @doc Start the handler supervisor.
--spec start_link(atom(), integer(), term()) -> term().
-start_link(HandlerModule, Port, UserOpts) ->
-    supervisor:start_link(?MODULE, [HandlerModule, Port, UserOpts]).
+-spec start_link(atom(), integer(), term(), term()) -> term().
+start_link(HandlerModule, Port, UserOpts, Args) ->
+    supervisor:start_link(?MODULE, [HandlerModule, Port, UserOpts, Args]).
 
 %%------------------------------------------------------------------------------
 %% Supervisor callbacks
 %%------------------------------------------------------------------------------
 
-init([HandlerModule, Port, UserOpts]) ->
+init([HandlerModule, Port, UserOpts, Args]) ->
     %% Open listening socket
     Opts = UserOpts ++ ?GEN_TCP_SERVER_OPTS,
     {ok, LSocket} = gen_tcp:listen(Port, remove_opts(Opts)),
 
     HandlerSpec = {gen_tcp_server_handler,
                    {gen_tcp_server_handler, start_link, [LSocket,
-                                                         HandlerModule]},
+                                                         HandlerModule,
+                                                         Args]},
                    temporary, infinity, worker, [gen_tcp_server_handler]},
     {ok, {{simple_one_for_one, 0, 1}, [HandlerSpec]}}.
 

--- a/test/gen_tcp_server_tests.erl
+++ b/test/gen_tcp_server_tests.erl
@@ -19,7 +19,7 @@
 %% @doc Eunit test suite for gen_tcp_server.
 -module(gen_tcp_server_tests).
 
--export([handle_accept/1,
+-export([handle_accept/2,
          handle_tcp/3]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -62,11 +62,12 @@ connection_test() ->
 %% gen_tcp_server callbacks
 %%------------------------------------------------------------------------------
 
-handle_accept(_) ->
-    {ok, state}.
+handle_accept(_Socket, Args) ->
+    ?assertEqual(Args, 'TEST_ARGS'),
+    {ok, Args}.
 
-handle_tcp(_, _, state) ->
-    {ok, state}.
+handle_tcp(_, _, State) ->
+    {ok, State}.
 
 %%------------------------------------------------------------------------------
 %% Helper functions
@@ -78,7 +79,7 @@ init() ->
     put(sockets, []).
 
 start_the_server() ->
-    {ok, Pid} = gen_tcp_server:start_link(?MODULE, ?PORT),
+    {ok, Pid} = gen_tcp_server:start_link(?MODULE, ?PORT, [], 'TEST_ARGS'),
     put(pid, Pid),
     timer:sleep(?TIMEOUT).
 


### PR DESCRIPTION
They will be received in the handle_accept callback.

Breaks the API in that the handle_accept callback now expects a second parameter: the initial arguments passed into gen_tcp_server:start_link/4.

Default arguments are [].
